### PR TITLE
Add Symfony2

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -48,6 +48,7 @@ class App extends Component {
         { name: "Rust", released: new Date(2015, 5, 5) },
         { name: "Sass", released: new Date(2006, 10, 28) },
         { name: "Swift", released: new Date(2014, 5, 2) },
+        { name: "Symfony 2", released: new Date(2011, 6, 0) },
         { name: "Tensorflow", released: new Date(2015, 11, 9) },
         { name: "This project", released: new Date(2018, 9, 25) },
         { name: "TypeScript", released: new Date(2012, 9, 1) },


### PR DESCRIPTION
Symfony was released in 2005, but Symfony2 is a different framework. Experience in Symfony1 would not really apply to later major versions. Sf2->4 are in continuity.