### PR TITLE
Specify year{s} inline

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -42,7 +42,7 @@ class App extends Component {
     for (let i = 0; i < this.state.technologies.length; i++) {
       rows.push(
         <p key={this.state.technologies[i].name} style={this.rowStyle(this.state.technologies[i].name)}>
-          <strong>{this.state.technologies[i].name}</strong> has been out for <strong>{this.daysSince(this.state.technologies[i].released)} years</strong>
+          <strong>{this.state.technologies[i].name}</strong> has been out for <strong>{this.daysSince(this.state.technologies[i].released)} year{(this.daysSince(this.state.technologies[i].released) !== 1) ? "s":""}</strong>
         </p>
       );
 


### PR DESCRIPTION
Potentially better solution than including a dependency for just 1 expression. Fixes https://github.com/jsrn/howoldisit/issues/72.