### PR TITLE
Add IBM Notes

### DIFF
--- a/src/technologies.js
+++ b/src/technologies.js
@@ -39,6 +39,7 @@ const technologies = [
   { name: "HTML", released: new Date(1993, 5, 1) },
   { name: "Hugo", released: new Date(2013, 5, 5) },
   { name: "Hyper-V", released: new Date(2008, 5, 26) },
+  { name: "IBM Notes", released: new Date(1989, 11, 7) },
   { name: "Java", released: new Date(1996, 9, 10) },
   { name: "JavaScript", released: new Date(1995, 11, 4) },
   { name: "Jekyll", released: new Date(2008, 10, 17) },


### PR DESCRIPTION
Version 1.0 of IBM Notes (formerly Lotus Notes) was released on 1989-12-07 according to [The History of Lotus Notes](https://www.slideshare.net/ktree19/history-of-lotus-notes).