### PR TITLE
add underline to links in footer

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -69,7 +69,11 @@ class App extends Component {
 
           {rows}
 
-          <p>Missing a technology? Find this repo on <a href="https://github.com/jsrn/howoldisit">GitHub</a>. Want a piece of me? Hurl abuse on <a href="https://twitter.com/jsrndoftime">Twitter</a>.</p>
+          <div id="footer">
+            <p>Missing a technology? Find this repo on <a href="https://github.com/jsrn/howoldisit">GitHub</a>. Want a piece of me? Hurl abuse on <a href="https://twitter.com/jsrndoftime">Twitter</a>.
+            </p>
+          </div>
+
         </main>
       </div>
     );

--- a/src/index.css
+++ b/src/index.css
@@ -12,3 +12,7 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }
+
+#footer a {
+  text-decoration: underline;
+}


### PR DESCRIPTION
This resolves: https://github.com/jsrn/howoldisit/issues/149 by adding underline to the links in the footer. 

<img width="1440" alt="screen shot 2018-10-29 at 7 04 11 pm" src="https://user-images.githubusercontent.com/6998954/47685667-a2165d80-dbad-11e8-8eb9-f595f906225e.png">

