### PR TITLE
Mesos has been around since at least 2010

### DIFF
--- a/src/technologies.js
+++ b/src/technologies.js
@@ -112,7 +112,7 @@ const technologies = [
   { name: "Markdown", released: new Date("2004-03-19"), link: "https://daringfireball.net/projects/markdown/" },
   { name: "Maven", released: new Date("2004-08-13"), link: "https://maven.apache.org/" },
   { name: "Mercurial", released: new Date("2005-04-19"), link: "https://www.mercurial-scm.org/" },
-  { name: "Mesos (Apache)", released: new Date("2016-08-27"), link: "http://mesos.apache.org/" },
+  { name: "Mesos (Apache)", released: new Date("2010-09-30"), link: "http://mesos.apache.org/" },
   { name: "Metal", released: new Date("2014-06-02"), link: "https://en.wikipedia.org/wiki/Metal_(API)" },
   { name: "Meteor", released: new Date("2012-01-20"), icon: "meteor" },
   { name: "Microsoft Azure", released: new Date("2010-02-01"), link: "https://azure.microsoft.com/en-us/" },


### PR DESCRIPTION
Per the [wikipedia article](https://en.wikipedia.org/wiki/Apache_Mesos), Twitter has been using Mesos since 2010. The best date I could find with a few minutes of Google searching is from [the original paper](https://systemsandpapers.s3.amazonaws.com/papers/mesos.pdf), dated 2010-09-30.