### PR TITLE
Adding Bootstrap 2 and 3 to the tech list

### DIFF
--- a/src/technologies.js
+++ b/src/technologies.js
@@ -21,6 +21,8 @@ const technologies = [
   { name: "BackBoneJS", released: new Date("2010-10-13"), icon: "backbone", link: "https://backbonejs.org/" },
   { name: "Bash", released: new Date("1989-06-08"), link: "https://en.wikipedia.org/wiki/Bash_(Unix_shell)" },
   { name: "BASIC", released: new Date("1964-05-01"), link: "https://en.wikipedia.org/wiki/BASIC" },
+  { name: "Bootstrap 2", released: new Date("2012-01-31"), icon: "bootstrap", link: "https://getbootstrap.com/" },
+  { name: "Bootstrap 3", released: new Date("2013-08-19"), icon: "bootstrap", link: "https://getbootstrap.com/" },
   { name: "Bootstrap 4", released: new Date("2018-01-18"), icon: "bootstrap", link: "https://getbootstrap.com/" },
   { name: "Brainfuck", released: new Date("1993-09-01"), link: "https://en.wikipedia.org/wiki/Brainfuck" },
   { name: "Bulma", released: new Date("2016-01-24"), link: "https://bulma.io/" },


### PR DESCRIPTION
Dates are According to https://en.wikipedia.org/wiki/Bootstrap_(front-end_framework) (which cross-refs https://web.archive.org/web/20170223125701/https://blog.twitter.com/2012/say-hello-to-bootstrap-2 and https://blog.getbootstrap.com/2013/08/19/bootstrap-3-released/)