### PR TITLE
Add KVM to technologies.

### DIFF
--- a/src/technologies.js
+++ b/src/technologies.js
@@ -110,6 +110,7 @@ const technologies = [
   { name: "Knockout", released: new Date("2010-08-05"), link: "https://knockoutjs.com/" },
   { name: "Kotlin", released: new Date("2011-07-01"), link: "https://kotlinlang.org/" },
   { name: "Kubernetes", released: new Date("2014-07-07"), link: "https://kubernetes.io/" },
+  { name: "KVM", released: new Date("2007-02-05"), icon: "linux", link: "https://www.linux-kvm.org/" },
   { name: "Laravel", released: new Date("2011-09-09"), icon: "laravel", link: "https://laravel.com/" },
   { name: "Laravel 4", released: new Date("2013-06-28"), icon: "laravel", link: "https://laravel.com/" },
   { name: "Laravel 5", released: new Date("2015-03-04"), icon: "laravel", link: "https://laravel.com/" },


### PR DESCRIPTION
This PR adds Kernel-based Virtual Machines to technologies. Uses the already provided `linux` icon as the assigned icon.

The date is based on the release of the Linux kernel version with which the KVM code was merged (2.6.20).