### PR TITLE
Add Fastify to technologies

### DIFF
--- a/src/technologies.js
+++ b/src/technologies.js
@@ -61,6 +61,7 @@ const technologies = [
   { name: "Erlang", released: new Date("1986-01-01"), icon: "erlang", link: "https://www.erlang.org/" },
   { name: "Express.js", released: new Date("2010-11-16"), link: "https://expressjs.com/" },
   { name: "F#", released: new Date("2005-06-21"), link: "https://fsharp.org/" },
+  { name: "Fastify", released: new Date("2018-03-06"), link: "https://www.fastify.io" },
   { name: "Firebase", released: new Date("2012-04-01"), icon: "Firebase", link: "https://firebase.google.com/" },
   { name: "Flask", released: new Date("2010-04-01"), link: "https://en.wikipedia.org/wiki/Flask_(web_framework)" },
   { name: "Flutter", released: new Date("2017-06-12"), link: "https://flutter.io/" },


### PR DESCRIPTION
Add Fastify to the list of technologies. Fastify is a fast and low overhead alternative to Express.js