### PR TITLE
Show "no technology found" message when search results are empty

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -35,10 +35,10 @@ class App extends Component {
     })
   }
 
-  rowStyle(name) {
+  rowStyle(rowHidden) {
     let style = {};
 
-    if (name.toLowerCase().indexOf(this.state.filter.toLowerCase()) === -1) {
+    if (rowHidden) {
       style.display = "none";
     }
 
@@ -90,11 +90,15 @@ class App extends Component {
   render() {
     let rows = [];
     let options = [];
-   
+    let atLeastOneRowShown = false;
     for (const tech of this.state.technologies) {
       let years = this.yearsSince(tech.released);
+      const rowHidden = tech.name.toLowerCase().indexOf(this.state.filter.toLowerCase()) === -1;
+      if(!rowHidden) {
+        atLeastOneRowShown = true;
+      }
       rows.push(
-        <p key={tech.name} style={this.rowStyle(tech.name)}>
+        <p key={tech.name} style={this.rowStyle(rowHidden)}>
           <a target={tech.link ? "_blank": ""} rel='noopener noreferrer' href={tech.link || '#'}>
             <Icon icon={tech.icon} />
             <strong>{tech.name}</strong>
@@ -133,6 +137,8 @@ class App extends Component {
           </div>    
 
           {rows}
+
+          {!atLeastOneRowShown && <p>No technology found by name <strong>{this.state.filter}</strong>.</p>}
 
           <div id="footer">
             <p>Missing a technology? Find this repo on <a href="https://github.com/jsrn/howoldisit">GitHub</a>. Want a piece of me? Hurl abuse on <a href="https://twitter.com/jsrndoftime">Twitter</a>.


### PR DESCRIPTION
If the search results yield empty results, it's little confusing for the user to understand that if the search is still underway or something went wrong. As it's always a JS search the results should appear pretty fast so there's no need for spinner. However, I think showing a clear message: `No technology found by name SEARCH.` will be helpful.

Below are the before and after screenshots to understand it better:

![image](https://user-images.githubusercontent.com/2310476/66030949-1117d700-e520-11e9-8b20-a059e62620ee.png)

**After:**

![image](https://user-images.githubusercontent.com/2310476/66031016-31e02c80-e520-11e9-9000-1e9bbda6625e.png)

And if the user still think the tech the user search for is missing, there's already a help section `Missing a technology?`.